### PR TITLE
Fix bogus perl syntax.

### DIFF
--- a/src/fatpack.pl
+++ b/src/fatpack.pl
@@ -161,7 +161,7 @@ sub main {
 		# gather all includes in all modules
 		while(my ($key, $value) = each %{$modules}) {
 			my $extracted = extractIncludes($value);
-			push @new, $extracted->@*;
+			push @new, @$extracted;
 		}
 
 		# Add all new modules and their contents


### PR DESCRIPTION
I haven't been writing perl in quite a few years, so maybe it's just new syntax I'm not familiar with, but my ubuntu 16.04 perl (v5.22.1) also doesn't like it.  It works for me with this change.