### PR TITLE
Add ping module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
 
-all: ./library/copy.lua ./library/file.lua ./library/lineinfile.lua ./library/opkg.lua ./library/slurp.lua ./library/stat.lua ./library/ubus.lua ./library/uci.lua
+all: ./library/copy.lua ./library/file.lua ./library/lineinfile.lua ./library/opkg.lua ./library/ping.lua ./library/slurp.lua ./library/stat.lua ./library/ubus.lua ./library/uci.lua
 
 WHITELIST=io,os,posix.,ubus
 FATPACKARGS=--whitelist $(WHITELIST) --truncate

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ repository currently implements the following modules:
 - [file](https://docs.ansible.com/ansible/file_module.html)
 - [lineinfile](https://docs.ansible.com/ansible/lineinfile_module.html)
 - opkg
+- [ping](https://docs.ansible.com/ansible/ping_module.html)
 - [stat](https://docs.ansible.com/ansible/stat_module.html)
 - ubus
 - uci
 
-Copy, file, lineinfile, stat and opkg are mostly straightforward ports of the
+Copy, file, lineinfile, stat, ping and opkg are mostly straightforward ports of the
 official python modules included in the Ansible v2.1.1.0 release. However, there
 were some simplifications made:
 - selinux file attributes are not supported
@@ -96,6 +97,7 @@ For the following modules, please refer to the upstream documentation
 - [file](https://docs.ansible.com/ansible/file_module.html)
 - [lineinfile](https://docs.ansible.com/ansible/lineinfile_module.html)
 - [opkg](https://docs.ansible.com/ansible/opkg_module.html)
+- [ping](https://docs.ansible.com/ansible/ping_module.html)
 - [stat](https://docs.ansible.com/ansible/stat_module.html)
 
 ## ubus module

--- a/src/ping.lua
+++ b/src/ping.lua
@@ -1,0 +1,23 @@
+#!/usr/bin/lua
+
+local Ansible = require("ansible")
+
+function main(arg)
+    local module = Ansible.new({
+        data = { default="pong" },
+    })
+
+    module:parse(arg[1])
+
+    local p = module:get_params()
+
+    local data = p["data"]
+
+    if "crash" == data then
+        module:fail_json({ msg="boom" })
+    else
+        module:exit_json({ changed=false, ping=data })
+    end
+end
+
+main(arg)


### PR DESCRIPTION
Hey,

This is a 'ping' module ripoff.
https://docs.ansible.com/ansible/latest/modules/ping_module.html

See how it works:
```
[0] $ ansible all -m ping
test | SUCCESS => {
    "changed": false, 
    "invocations": {
        "module_args": {
            "data": "pong"
        }
    }, 
    "ping": "pong"
}
[0] $ ansible all -m ping -a data=hello
test | SUCCESS => {
    "changed": false, 
    "invocations": {
        "module_args": {
            "data": "hello"
        }
    }, 
    "ping": "hello"
}
[0] $ ansible all -m ping -a data=crash
test | FAILED! => {
    "changed": false, 
    "invocations": {
        "module_args": {
            "data": "crash"
        }
    }, 
    "msg": "boom"
}
[2] $
```