### PR TITLE
Add service module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
 
-all: ./library/copy.lua ./library/file.lua ./library/lineinfile.lua ./library/opkg.lua ./library/ping.lua ./library/slurp.lua ./library/stat.lua ./library/ubus.lua ./library/uci.lua
+all: ./library/copy.lua ./library/file.lua ./library/lineinfile.lua ./library/opkg.lua ./library/ping.lua ./library/service.lua ./library/slurp.lua ./library/stat.lua ./library/ubus.lua ./library/uci.lua
 
 WHITELIST=io,os,posix.,ubus
 FATPACKARGS=--whitelist $(WHITELIST) --truncate

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ repository currently implements the following modules:
 - [lineinfile](https://docs.ansible.com/ansible/lineinfile_module.html)
 - opkg
 - [ping](https://docs.ansible.com/ansible/ping_module.html)
+- [service](https://docs.ansible.com/ansible/service_module.html)
 - [stat](https://docs.ansible.com/ansible/stat_module.html)
 - ubus
 - uci
 
-Copy, file, lineinfile, stat, ping and opkg are mostly straightforward ports of the
+Copy, file, lineinfile, stat, service, ping and opkg are mostly straightforward ports of the
 official python modules included in the Ansible v2.1.1.0 release. However, there
 were some simplifications made:
 - selinux file attributes are not supported
@@ -98,6 +99,7 @@ For the following modules, please refer to the upstream documentation
 - [lineinfile](https://docs.ansible.com/ansible/lineinfile_module.html)
 - [opkg](https://docs.ansible.com/ansible/opkg_module.html)
 - [ping](https://docs.ansible.com/ansible/ping_module.html)
+- [service](https://docs.ansible.com/ansible/service_module.html)
 - [stat](https://docs.ansible.com/ansible/stat_module.html)
 
 ## ubus module

--- a/src/fileutils.lua
+++ b/src/fileutils.lua
@@ -94,6 +94,16 @@ function FileUtil.islnk(path)
 	end
 end
 
+function FileUtil.isfile(path)
+	local pstat = stat.lstat(path)
+
+	if pstat then
+		return 0 ~= stat.S_ISREG(pstat['st_mode'])
+	else
+		return false
+	end
+end
+
 function FileUtil.stat(path)
 	return stat.stat(path)
 end

--- a/src/service.lua
+++ b/src/service.lua
@@ -1,0 +1,96 @@
+#!/usr/bin/lua
+
+local Ansible = require("ansible")
+local File = require("fileutils")
+
+function service_script(service)
+    return "/etc/init.d/" .. service
+end
+
+function service_exists(service)
+    return File.isfile(service_script(service))
+end
+
+function service_enabled(module, service)
+    local rc, out, err = service_command(module, service, "enabled")
+
+    return 0 == rc, out, err
+end
+
+function service_command(module, service, action)
+    return module:run_command(service_script(service) .. " " .. action)
+end
+
+function service_running(module, service)
+    if 0 == module:run_command("pgrep -P 1 " .. service) then
+        return true
+    end
+
+    return false
+end
+
+function main(arg)
+    local module = Ansible.new({
+        name = { required = true },
+        state = { choices = { "", "started", "stopped", "restarted", "reloaded" } },
+        enabled = { type = 'bool' },
+    })
+
+    module:parse(arg[1])
+
+    local p = module:get_params()
+
+    local service = p["name"]
+    local state = p["state"]
+    local enable = p["enabled"]
+
+    local changed = false
+    local msg = {}
+    local actions = {}
+
+    if (state == nil or state == "") and (enable == nil) then
+        module:fail_json({ msg = "at least one of 'state' and 'enabled' are required" })
+    end
+
+    if not service_exists(service) then
+        module:fail_json({ msg = string.format("service '%s' does not exist", service) })
+    end
+
+    if enable then
+        if not service_enabled(module, service) then
+            actions[#actions + 1] = "enable"
+        end
+    elseif enable == false then
+        if service_enabled(module, service) then
+            actions[#actions + 1] = "disable"
+        end
+    end
+
+    if state ~= nil then
+        local action = string.gsub(state, "p?ed$", "")
+
+        if not (("start" == action and service_running(module, service)) or ("stop" == action and not service_running(module, service))) then
+            actions[#actions + 1] = action
+        end
+    end
+
+    if #actions > 0 then
+        if not module:check_mode() then
+            for i = 1, #actions do
+                local rc, out, err = service_command(module, service, actions[i])
+
+                if rc ~= 0 then
+                    module:fail_json({ msg = string.format("service '%s' has failed to %s", service, actions[i]),
+                                       service = { rc = rc, out = out, err = err } })
+                end
+
+                msg[#msg + 1] = string.format("executed '%s' command", actions[i])
+            end
+        end
+        changed = true
+    end
+
+    module:exit_json({ changed = changed, msg = table.concat(msg, "; ") })
+end
+
+main(arg)


### PR DESCRIPTION
Hello,

I need 'service' module in my own playbooks, so I wrote the code for it.

Although its named 'service', this is a clone of 'openwrt_init' which is actually called when dealing with services on openwrt hosts.

https://docs.ansible.com/ansible/latest/modules/service_module.html
https://docs.ansible.com/ansible/latest/modules/openwrt_init_module.html

Let me know if you see any possible code improvements there.

Regards